### PR TITLE
Sync implementation with evaera's promise repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable corepack
+        run: corepack enable
+
       - uses: actions/setup-node@v3
         with:
           node-version: "latest"
           cache: "yarn"
           cache-dependency-path: "yarn.lock"
-
-      - name: Update yarn
-        run: yarn set version stable
 
       - name: Install packages
         run: yarn install --immutable
@@ -57,6 +57,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable corepack
+        run: corepack enable
+
       - uses: Roblox/setup-foreman@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -66,9 +69,6 @@ jobs:
           node-version: "latest"
           cache: "yarn"
           cache-dependency-path: "yarn.lock"
-
-      - name: Update yarn
-        run: yarn set version stable
 
       - name: Install packages
         run: yarn install --immutable
@@ -136,6 +136,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable corepack
+        run: corepack enable
+
       - uses: Roblox/setup-foreman@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -145,9 +148,6 @@ jobs:
           node-version: "latest"
           cache: "yarn"
           cache-dependency-path: "yarn.lock"
-
-      - name: Update yarn
-        run: yarn set version stable
 
       - name: Install packages
         run: yarn install --immutable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable corepack
+        run: corepack enable
+
       - uses: Roblox/setup-foreman@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -25,9 +28,6 @@ jobs:
           node-version: "latest"
           cache: "yarn"
           cache-dependency-path: "yarn.lock"
-
-      - name: Update yarn
-        run: yarn set version stable
 
       - name: Install packages
         run: yarn install --immutable

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /luacov.*.out
 node_modules/
-.vscode
 .yarn
 
 build

--- a/.luau-analyze.json
+++ b/.luau-analyze.json
@@ -1,0 +1,6 @@
+{
+  "luau-lsp.require.mode": "relativeToFile",
+  "luau-lsp.require.directoryAliases": {
+    "@pkg": "node_modules/.luau-aliases"
+  }
+}

--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,10 @@
+{
+  "languageMode": "strict",
+  "lintErrors": true,
+  "lint": {
+    "*": true
+  },
+  "aliases": {
+    "pkg": "./node_modules/.luau-aliases"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "luau-lsp.completion.imports.requireStyle": "alwaysRelative",
+  "luau-lsp.completion.imports.enabled": true,
+  "luau-lsp.sourcemap.autogenerate": false,
+  "luau-lsp.sourcemap.enabled": false
+}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,1 @@
-compressionLevel: mixed
-
-enableGlobalCache: false
-
 nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-4.0.2.cjs

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1054,13 +1054,7 @@ function Promise.delay(seconds)
 		task.delay(seconds, function()
 			resolve(Promise._getTime() - startTime)
 		end)
-			end)
-			end)
-		end)
-	end
 	end)
-		end)
-	end
 end
 
 --[=[

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "main": "lib/init.lua",
   "scripts": {
     "prepare": "npmluau",
-    "build-assets": "sh ./scripts/build-assets.sh"
+    "build-assets": "sh ./scripts/build-assets.sh",
+    "clean": "rm -rf roblox build node_modules"
   },
   "devDependencies": {
-    "npmluau": "^0.1.1"
+    "npmluau": "^0.1.2"
   },
-  "packageManager": "yarn@4.0.2"
+  "packageManager": "yarn@4.6.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,38 +3,38 @@
 
 __metadata:
   version: 8
-  cacheKey: 10
+  cacheKey: 10c0
 
 "@jsdotlua/promise@workspace:.":
   version: 0.0.0-use.local
   resolution: "@jsdotlua/promise@workspace:."
   dependencies:
-    npmluau: "npm:^0.1.1"
+    npmluau: "npm:^0.1.2"
   languageName: unknown
   linkType: soft
 
 "commander@npm:^11.0.0":
   version: 11.1.0
   resolution: "commander@npm:11.1.0"
-  checksum: 66bd2d8a0547f6cb1d34022efb25f348e433b0e04ad76a65279b1b09da108f59a4d3001ca539c60a7a46ea38bcf399fc17d91adad76a8cf43845d8dcbaf5cda1
+  checksum: 13cc6ac875e48780250f723fb81c1c1178d35c5decb1abb1b628b3177af08a8554e76b2c0f29de72d69eef7c864d12613272a71fabef8047922bc622ab75a179
   languageName: node
   linkType: hard
 
-"npmluau@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "npmluau@npm:0.1.1"
+"npmluau@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "npmluau@npm:0.1.2"
   dependencies:
     commander: "npm:^11.0.0"
     walkdir: "npm:^0.4.1"
   bin:
     npmluau: main.js
-  checksum: 7d8a06998a72e7f002ded33b4c52a5a54431be7ecb8468ddcd28aaeba6d78eeca28fe9db175962e7a30cd12b2405f15a8d2a58f7e7bd5fdba67b5e4f800536b5
+  checksum: 665e23da3e4329faaa324bc98cebc23e7a540bde6dabbf8b6033dc7360fc74d635688fe712a919462bfc3d4db8c54c503c7e0cd0bf92c704b55afe4087ff0e3c
   languageName: node
   linkType: hard
 
 "walkdir@npm:^0.4.1":
   version: 0.4.1
   resolution: "walkdir@npm:0.4.1"
-  checksum: 54cbe7afc5fb811a55748b0bfa077a9a4aa43f568eb5857db9785af9728e1ad8b1ecf6b9ce6f14b405c6124939a92522e36aaa0397f3f52a9a7a08496f2eebe1
+  checksum: 88e635aa9303e9196e4dc15013d2bd4afca4c8c8b4bb27722ca042bad213bb882d3b9141b3b0cca6bfb274f7889b30cf58d6374844094abec0016f335c5414dc
   languageName: node
   linkType: hard


### PR DESCRIPTION
_Currently a draft since I want to test this branch on some repositories._

This PR push the repo closer to evaera's [promise](https://github.com/evaera/roblox-lua-promise).

Briefly, the behavior of finally is changing, see [#59](https://github.com/evaera/roblox-lua-promise/issues/59) and [#66](https://github.com/evaera/roblox-lua-promise/issues/66).

Also includes removing:

- `promise:done()`
- `promise:doneCall()`
- `promise:doneReturn()`

These functions are not used in any jsdotlua projects.

Todo:

- [ ] sync tests